### PR TITLE
[WELBA-92] Prevent double payment on Stripe

### DIFF
--- a/MWStripePlugin.podspec
+++ b/MWStripePlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWStripePlugin'
-    s.version               = '0.0.13'
+    s.version               = '0.0.14'
     s.summary               = 'Stripe plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Stripe plugin for MobileWorkflow on iOS, containg Stripe related steps:

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/L10n.swift
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/L10n.swift
@@ -15,4 +15,5 @@ extension L10n {
     
     static let payWithStripe = L10n.localizedString(key: "PAY_WITH_STRIPE")
     static let loading = L10n.localizedString(key: "LOADING")
+    static let `continue` = L10n.localizedString(key: "CONTINUE")
 }

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/Localizable.strings
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/Localizable.strings
@@ -7,3 +7,4 @@
 */
 "PAY_WITH_STRIPE" = "Pay With Stripe";
 "LOADING" = "Loading...";
+"CONTINUE" = "Continue";

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
@@ -55,15 +55,19 @@ public class MWStripeViewController: MWStepViewController {
         self.view.addPinnedSubview(VStack)
         
         self.loadItemsToPurchase()
-        
-        self.configureButton(title: L10n.loading, isEnabled: false)
-        self.fetchStripeConfiguration()
     }
     
     private func configureButton(title: String, isEnabled: Bool) {
         self.navigationFooterConfig = NavigationFooterView.Config(primaryButton: ButtonConfig(isEnabled: isEnabled, style: .primary, title: title, action: didTapCheckoutButton),
                                                                   secondaryButton: nil,
                                                                   hasBlurredBackground: false)
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Fetch every time that the view appears in case that the suer navigates back. If they do,
+        // the server will error out and we'll display a "continue" button if they've already paid.
+        self.fetchStripeConfiguration()
     }
     
     //MARK: Actions
@@ -112,6 +116,7 @@ public class MWStripeViewController: MWStepViewController {
     
     //MARK: Stripe
     private func fetchStripeConfiguration() {
+        self.configureButton(title: L10n.loading, isEnabled: false)
         guard let url = self.stripeStep.session.resolve(url: stripeStep.paymentIntentURL) else {
             assertionFailure("Failed to resolve the URL")
             return

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
@@ -65,7 +65,7 @@ public class MWStripeViewController: MWStepViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // Fetch every time that the view appears in case that the suer navigates back. If they do,
+        // Fetch every time that the view appears in case that the user navigates back. If they do,
         // the server will error out and we'll display a "continue" button if they've already paid.
         self.fetchStripeConfiguration()
     }


### PR DESCRIPTION
The server has not yet implemented this check, but we've agreed that if the server returns a 409 when asking for the Stripe configuration, it means that the user has already paid.