### PR TITLE
Animated transition for remotely loaded images

### DIFF
--- a/MWStripePlugin.podspec
+++ b/MWStripePlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWStripePlugin'
-    s.version               = '0.1.1'
+    s.version               = '0.1.2'
     s.summary               = 'Stripe plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Stripe plugin for MobileWorkflow on iOS, containg Stripe related steps:

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
@@ -206,8 +206,8 @@ extension MWStripeViewController: UITableViewDataSource, UITableViewDelegate {
         cell.configure(with: item)
         
         if let imageURL = item.imageURL {
-            let cancellable = self.stripeStep.services.imageLoadingService.asyncLoad(image: imageURL, session: self.stripeStep.session) { [weak self] image in
-                (cell.stackView.arrangedSubviews.first(where: { $0 is UIImageView }) as? UIImageView)?.image = image
+            let cancellable = self.stripeStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageURL, session: self.stripeStep.session) { [weak self] image, fromCache in
+                (cell.stackView.arrangedSubviews.first(where: { $0 is UIImageView }) as? UIImageView)?.transition(to: image, animated: !fromCache)
                 cell.setNeedsLayout()
                 self?.ongoingImageLoads.removeValue(forKey: indexPath)
             }

--- a/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
+++ b/MWStripePlugin/MWStripePlugin/StripePlugin/MWStripeViewController.swift
@@ -206,8 +206,8 @@ extension MWStripeViewController: UITableViewDataSource, UITableViewDelegate {
         cell.configure(with: item)
         
         if let imageURL = item.imageURL {
-            let cancellable = self.stripeStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageURL, session: self.stripeStep.session) { [weak self] image, fromCache in
-                (cell.stackView.arrangedSubviews.first(where: { $0 is UIImageView }) as? UIImageView)?.transition(to: image, animated: !fromCache)
+            let cancellable = self.stripeStep.services.imageLoadingService.load(image: imageURL, session: self.stripeStep.session) { [weak self] result in
+                (cell.stackView.arrangedSubviews.first(where: { $0 is UIImageView }) as? UIImageView)?.transition(to: result.image, animated: result.wasLoadedRemotely)
                 cell.setNeedsLayout()
                 self?.ongoingImageLoads.removeValue(forKey: indexPath)
             }


### PR DESCRIPTION
### Task

[[iOS] [Android] Image loading states](https://3.basecamp.com/5245563/buckets/26145695/todos/4825281143/edit?replace=true)

### Summary

Adding animated transition to loaded image.

### Implementation

Updated to use `ImageLoadingService` `load(image:session:completion:)` and `UIImageView` `transition(to:animated:completion:)` to update the image. 
